### PR TITLE
Implement OwnershipGraph for Borrowing Rules in Rust

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -55,6 +55,7 @@ pub enum BorrowError {
     VariableNotDefined(String),
     VariableNotInitialized(String),
     VariableDeclaredDuplicate(String),
+    VariableNotInScope(String),
     InvalidBorrowMutablyBorrowed(String),
     InvalidBorrow(String),
     NoScopeAvailable(String),
@@ -73,42 +74,33 @@ impl std::fmt::Display for BorrowError {
                 f,
                 "Cannot borrow {var} as it is currently being immutably borrowed"
             ),
-            BorrowError::DeclaredWithoutInitialValue(var) => write!(
-                f,
-                "Variable {var} is declared without an initial value"
-            ),
-            BorrowError::VariableNotDefined(var) => write!(
-                f,
-                "Variable {var} is not defined in the current scope"
-            ),
-            BorrowError::VariableNotInitialized(var) => write!(
-                f,
-                "Variable {var} is not initialized"
-            ),
-            BorrowError::VariableDeclaredDuplicate(var) => write!(
-                f,
-                "Variable {var} is already declared in the current scope"
-            ),
+            BorrowError::DeclaredWithoutInitialValue(var) => {
+                write!(f, "Variable {var} is declared without an initial value")
+            }
+            BorrowError::VariableNotDefined(var) => {
+                write!(f, "Variable {var} is not defined in the current scope")
+            }
+            BorrowError::VariableNotInitialized(var) => {
+                write!(f, "Variable {var} is not initialized")
+            }
+            BorrowError::VariableDeclaredDuplicate(var) => {
+                write!(f, "Variable {var} is already declared in the current scope")
+            },
+            BorrowError::VariableNotInScope(var) => {
+                write!(f, "Variable {var} is not in scope")
+            },
             BorrowError::InvalidBorrowMutablyBorrowed(var) => write!(
                 f,
                 "Cannot borrow {var}. It is currently being mutably borrowed"
             ),
-            BorrowError::InvalidBorrow(var) => write!(
-                f,
-                "Invalid borrow of {var}"
-            ),
-            BorrowError::NoScopeAvailable(var) => write!(
-                f,
-                "No scope available for variable of {var}"
-            ),
-            BorrowError::CannotBorrowMutable(var) => write!(
-                f,
-                "Cannot borrow {var} as mutable"
-            ),
-            BorrowError::CannotBorrowImmutable(var) => write!(
-                f,
-                "Cannot borrow {var} as immutable"
-            ),
+            BorrowError::InvalidBorrow(var) => write!(f, "Invalid borrow of {var}"),
+            BorrowError::NoScopeAvailable(var) => {
+                write!(f, "No scope available for variable of {var}")
+            }
+            BorrowError::CannotBorrowMutable(var) => write!(f, "Cannot borrow {var} as mutable"),
+            BorrowError::CannotBorrowImmutable(var) => {
+                write!(f, "Cannot borrow {var} as immutable")
+            }
         }
     }
 }
@@ -118,11 +110,18 @@ impl std::fmt::Debug for BorrowError {
         match self {
             BorrowError::BorrowedMutable(var) => write!(f, "BorrowedMutable: {var}"),
             BorrowError::BorrowedImmut(var) => write!(f, "BorrowedImmut: {var}"),
-            BorrowError::DeclaredWithoutInitialValue(var) => write!(f, "DeclaredWithoutInitialValue: {var}"),
+            BorrowError::DeclaredWithoutInitialValue(var) => {
+                write!(f, "DeclaredWithoutInitialValue: {var}")
+            }
             BorrowError::VariableNotDefined(var) => write!(f, "VariableNotDefined: {var}"),
             BorrowError::VariableNotInitialized(var) => write!(f, "VariableNotInitialized: {var}"),
-            BorrowError::VariableDeclaredDuplicate(var) => write!(f, "VariableDeclaredDuplicate: {var}"),
-            BorrowError::InvalidBorrowMutablyBorrowed(var) => write!(f, "InvalidBorrowMutablyBorrowed: {var}"),
+            BorrowError::VariableDeclaredDuplicate(var) => {
+                write!(f, "VariableDeclaredDuplicate: {var}")
+            },
+            BorrowError::VariableNotInScope(var) => write!(f, "VariableNotInScope: {var}"),
+            BorrowError::InvalidBorrowMutablyBorrowed(var) => {
+                write!(f, "InvalidBorrowMutablyBorrowed: {var}")
+            }
             BorrowError::InvalidBorrow(var) => write!(f, "InvalidBorrow: {var}"),
             BorrowError::NoScopeAvailable(var) => write!(f, "NoScopeAvailable: {var}"),
             BorrowError::CannotBorrowMutable(var) => write!(f, "CannotBorrowMutable: {var}"),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -46,3 +46,89 @@ impl std::fmt::Debug for LifetimeError {
 }
 
 impl std::error::Error for LifetimeError {}
+
+#[derive(PartialEq, Eq, Clone)]
+pub enum BorrowError {
+    BorrowedMutable(String),
+    BorrowedImmut(String),
+    DeclaredWithoutInitialValue(String),
+    VariableNotDefined(String),
+    VariableNotInitialized(String),
+    VariableDeclaredDuplicate(String),
+    InvalidBorrowMutablyBorrowed(String),
+    InvalidBorrow(String),
+    NoScopeAvailable(String),
+    CannotBorrowMutable(String),
+    CannotBorrowImmutable(String),
+}
+
+impl std::fmt::Display for BorrowError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BorrowError::BorrowedMutable(var) => write!(
+                f,
+                "Cannot borrow {var} as it is currently being mutably borrowed"
+            ),
+            BorrowError::BorrowedImmut(var) => write!(
+                f,
+                "Cannot borrow {var} as it is currently being immutably borrowed"
+            ),
+            BorrowError::DeclaredWithoutInitialValue(var) => write!(
+                f,
+                "Variable {var} is declared without an initial value"
+            ),
+            BorrowError::VariableNotDefined(var) => write!(
+                f,
+                "Variable {var} is not defined in the current scope"
+            ),
+            BorrowError::VariableNotInitialized(var) => write!(
+                f,
+                "Variable {var} is not initialized"
+            ),
+            BorrowError::VariableDeclaredDuplicate(var) => write!(
+                f,
+                "Variable {var} is already declared in the current scope"
+            ),
+            BorrowError::InvalidBorrowMutablyBorrowed(var) => write!(
+                f,
+                "Cannot borrow {var}. It is currently being mutably borrowed"
+            ),
+            BorrowError::InvalidBorrow(var) => write!(
+                f,
+                "Invalid borrow of {var}"
+            ),
+            BorrowError::NoScopeAvailable(var) => write!(
+                f,
+                "No scope available for variable of {var}"
+            ),
+            BorrowError::CannotBorrowMutable(var) => write!(
+                f,
+                "Cannot borrow {var} as mutable"
+            ),
+            BorrowError::CannotBorrowImmutable(var) => write!(
+                f,
+                "Cannot borrow {var} as immutable"
+            ),
+        }
+    }
+}
+
+impl std::fmt::Debug for BorrowError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BorrowError::BorrowedMutable(var) => write!(f, "BorrowedMutable: {var}"),
+            BorrowError::BorrowedImmut(var) => write!(f, "BorrowedImmut: {var}"),
+            BorrowError::DeclaredWithoutInitialValue(var) => write!(f, "DeclaredWithoutInitialValue: {var}"),
+            BorrowError::VariableNotDefined(var) => write!(f, "VariableNotDefined: {var}"),
+            BorrowError::VariableNotInitialized(var) => write!(f, "VariableNotInitialized: {var}"),
+            BorrowError::VariableDeclaredDuplicate(var) => write!(f, "VariableDeclaredDuplicate: {var}"),
+            BorrowError::InvalidBorrowMutablyBorrowed(var) => write!(f, "InvalidBorrowMutablyBorrowed: {var}"),
+            BorrowError::InvalidBorrow(var) => write!(f, "InvalidBorrow: {var}"),
+            BorrowError::NoScopeAvailable(var) => write!(f, "NoScopeAvailable: {var}"),
+            BorrowError::CannotBorrowMutable(var) => write!(f, "CannotBorrowMutable: {var}"),
+            BorrowError::CannotBorrowImmutable(var) => write!(f, "CannotBorrowImmutable: {var}"),
+        }
+    }
+}
+
+impl std::error::Error for BorrowError {}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -85,10 +85,10 @@ impl std::fmt::Display for BorrowError {
             }
             BorrowError::VariableDeclaredDuplicate(var) => {
                 write!(f, "Variable {var} is already declared in the current scope")
-            },
+            }
             BorrowError::VariableNotInScope(var) => {
                 write!(f, "Variable {var} is not in scope")
-            },
+            }
             BorrowError::InvalidBorrowMutablyBorrowed(var) => write!(
                 f,
                 "Cannot borrow {var}. It is currently being mutably borrowed"
@@ -117,7 +117,7 @@ impl std::fmt::Debug for BorrowError {
             BorrowError::VariableNotInitialized(var) => write!(f, "VariableNotInitialized: {var}"),
             BorrowError::VariableDeclaredDuplicate(var) => {
                 write!(f, "VariableDeclaredDuplicate: {var}")
-            },
+            }
             BorrowError::VariableNotInScope(var) => write!(f, "VariableNotInScope: {var}"),
             BorrowError::InvalidBorrowMutablyBorrowed(var) => {
                 write!(f, "InvalidBorrowMutablyBorrowed: {var}")
@@ -131,3 +131,30 @@ impl std::fmt::Debug for BorrowError {
 }
 
 impl std::error::Error for BorrowError {}
+
+#[derive(PartialEq, Eq, Clone)]
+pub enum OwnerGraphError {
+    MultipleOwners(String),
+}
+
+impl std::fmt::Debug for OwnerGraphError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OwnerGraphError::MultipleOwners(variable) => {
+                write!(f, "Variable {variable} has multiple owners")
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for OwnerGraphError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OwnerGraphError::MultipleOwners(variable) => {
+                write!(f, "Variable {variable} has multiple owners")
+            }
+        }
+    }
+}
+
+impl std::error::Error for OwnerGraphError {}

--- a/src/lifetime.rs
+++ b/src/lifetime.rs
@@ -34,14 +34,14 @@ pub struct Scope<'a> {
 
 impl Variable {
     /// Creates a new `Variable` instance with given `state` and `scope_id`.
-    /// 
+    ///
     /// The `is_allocated` field is set to `true` if the `state` is not `Uninitialized`.
     pub fn new(state: BorrowState, scope_id: usize) -> Self {
         let is_allocated = state != BorrowState::Uninitialized;
 
-        Self { 
-            state, 
-            scope_id, 
+        Self {
+            state,
+            scope_id,
             is_allocated,
         }
     }
@@ -52,7 +52,7 @@ impl Variable {
     }
 
     /// Sets the state of the variable.
-    /// 
+    ///
     /// The `is_allocated` field is updated based on the new `state`.
     pub fn set_state(&mut self, state: BorrowState) {
         self.is_allocated = state != BorrowState::Uninitialized;
@@ -67,7 +67,7 @@ impl Variable {
 
 impl<'a> Scope<'a> {
     /// Creates a new `scope` instance with the given `parent` scope.
-    /// 
+    ///
     /// The ID is automatically generated.
     pub fn new(parent: Option<&'a Scope<'a>>) -> Self {
         Self {
@@ -93,7 +93,7 @@ impl<'a> Scope<'a> {
     }
 
     /// Insert a variable\ with the given `state` into the scope.
-    /// 
+    ///
     /// The variable is allocated memory if its state is not `Uninitialized`.
     pub fn insert(&mut self, var: &'a str, state: BorrowState) {
         self.variables.insert(var, Variable::new(state, self.id));
@@ -105,7 +105,7 @@ impl<'a> Scope<'a> {
     }
 
     /// Sets the state of a variable in the scope.
-    /// 
+    ///
     /// The variable's memory allocation is updated based on the new state.
     pub fn set_state(&mut self, var: &'a str, state: BorrowState) {
         if let Some(variable) = self.variables.get_mut(var) {
@@ -120,7 +120,7 @@ impl<'a> Scope<'a> {
     }
 
     /// Checks the lifetime of a variable in the scope or any of its parent scopes.
-    /// 
+    ///
     /// if the variable's lifetime is too short, an error is returned.
     pub fn check_lifetime(&self, var: &'a str, borrow_id: usize) -> Result<(), LifetimeError> {
         let variable = self.get_variable(var)?;
@@ -143,7 +143,7 @@ impl<'a> Scope<'a> {
     }
 
     /// Checks the borrow rules of a variable in the scope or any of its parent scopes.
-    /// 
+    ///
     /// if the variable is borrowed mutably, an error is returned.
     pub fn check_borrow_rules(&self, var: &'a str) -> Result<(), LifetimeError> {
         let variable = self.get_variable(var)?;
@@ -157,7 +157,7 @@ impl<'a> Scope<'a> {
     }
 
     /// Returns a reference to a variable in the scope or any of its parent scopes.
-    /// 
+    ///
     /// If the variable is not found, an error is returned.
     fn get_variable(&self, var: &'a str) -> Result<&Variable, LifetimeError> {
         if let Some(variable) = self.variables.get(var) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,5 +6,6 @@ mod lexer;
 mod lifetime;
 mod parser;
 mod token;
+mod ownership;
 
 fn main() {}

--- a/src/ownership.rs
+++ b/src/ownership.rs
@@ -1,0 +1,182 @@
+use std::collections::BTreeMap;
+
+use crate::{ast::{Statement, Expression}, errors::OwnerGraphError};
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+struct OwnershipGraph {
+    graph: BTreeMap<String, Vec<String>>,
+}
+
+impl OwnershipGraph {
+    pub fn new() -> Self {
+        Self {
+            graph: BTreeMap::new(),
+        }
+    }
+
+    pub fn add_owner(&mut self, owner: &str, variable: &str) {
+        let entry = self.graph.entry(owner.to_string()).or_insert_with(Vec::new);
+        if !entry.contains(&variable.to_string()) {
+            entry.push(variable.to_string());
+        }
+    }
+
+    pub fn add_borrower(&mut self, owner: &str, borrower: &str) {
+        if let Some(borrowers) = self.graph.get_mut(owner) {
+            if !borrowers.contains(&borrower.to_string()) {
+                borrowers.push(borrower.to_string());
+            }
+        }
+    }
+
+    pub fn remove_owner(&mut self, owner: &str, variable: &str) {
+        if let Some(owners) = self.graph.get_mut(owner) {
+            owners.retain(|x| x != variable);
+        }
+    }
+
+    pub fn remove_borrower(&mut self, owner: &str, borrower: &str) {
+        if let Some(borrowers) = self.graph.get_mut(owner) {
+            borrowers.retain(|x| x != borrower);
+        }
+    }
+}
+
+fn build_ownership_graph(stmts: &[Statement]) -> Result<OwnershipGraph, OwnerGraphError> {
+    let mut graph = OwnershipGraph::new();
+    let mut current_owner = "".to_string();
+
+    for stmt in stmts {
+        match stmt {
+            Statement::VariableDecl { name, is_borrowed, value } => {
+                if *is_borrowed {
+                    if let Some(Expression::Reference(ref_var)) = value {
+                        current_owner = ref_var.clone();
+                        graph.add_borrower(&current_owner, name);
+                        // current_owner = name.clone();
+                    }
+                }
+                graph.add_owner(&current_owner, name);
+                current_owner = name.clone();
+            }
+            Statement::Scope(scope) =>  {
+                let prev_owner = current_owner.clone();
+                let mut declared_in_scope = vec![];
+
+                for inner_stmt in scope {
+                    if let Statement::VariableDecl { name, value, is_borrowed } = inner_stmt {
+                        declared_in_scope.push(name.clone());
+
+                        if *is_borrowed {
+                            if let Some(Expression::Reference(ref_var)) = value {
+                                current_owner = ref_var.clone();
+                                graph.add_borrower(&current_owner, name);
+                                // current_owner = name.clone();
+                            }
+                        }
+
+                        graph.add_owner(&prev_owner, name);
+                        current_owner = name.clone();
+                    }
+                }
+
+                for var in declared_in_scope {
+                    graph.remove_owner(&prev_owner, &var);
+                    current_owner = prev_owner.clone();
+                }
+            }
+
+            _ => {}
+        }
+    }
+
+    for (variable, owners) in &graph.graph {
+        if owners.len() > 1 {
+            for owner in owners {
+                if owner == variable {
+                    return Err(OwnerGraphError::MultipleOwners(variable.clone()));
+                }
+            }
+        }
+    }
+
+    Ok(graph)
+}
+
+#[cfg(test)]
+mod ownership_graph_tests {
+    use super::*;
+
+    #[test]
+    fn test_non_violate_borrowing_rule() {
+        let stmts = vec![
+            Statement::VariableDecl {
+                name: "a".into(),
+                is_borrowed: false,
+                value: None,
+            },
+            Statement::VariableDecl {
+                name: "b".into(),
+                is_borrowed: true,
+                value: Some(Expression::Reference("a".into())),
+            },
+            Statement::VariableDecl {
+                name: "c".into(),
+                is_borrowed: true,
+                value: Some(Expression::Reference("a".into())),
+            },
+        ];
+        let graph = build_ownership_graph(&stmts).unwrap();
+        
+        // println!("{:?}", graph);
+
+        assert_eq!(
+            graph,
+            OwnershipGraph {
+                graph: vec![
+                    ("".into(), vec!["a".into()]),
+                    ("a".into(), vec!["b".into(), "c".into()]),
+                ]
+                .into_iter()
+                .collect(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_include_the_borrowing_of_other_variable() {
+        let stmts = vec![
+            Statement::VariableDecl {
+                name: "x".into(),
+                is_borrowed: false,
+                value: None,
+            },
+            Statement::VariableDecl {
+                name: "y".into(),
+                is_borrowed: true,
+                value: Some(Expression::Reference("x".into())),
+            },
+            Statement::VariableDecl {
+                name: "z".into(),
+                is_borrowed: true,
+                value: Some(Expression::Reference("y".into())),
+            },
+        ];
+        let graph = build_ownership_graph(&stmts).unwrap();
+
+        // println!("{:?}", graph);
+
+        assert_eq!(
+            graph,
+            OwnershipGraph {
+                graph: vec![
+                    ("".into(), vec!["x".into()]),
+                    ("x".into(), vec!["y".into()]),
+                    ("y".into(), vec!["z".into()]),
+                ]
+                .into_iter()
+                .collect(),
+            }
+        );
+    }
+}


### PR DESCRIPTION
In this PR, we have implemented the `OwnershipGraph` data structure to enforce borrowing rules in this language.

Changes made:

1. **Implementation of `OwnershipGraph`**: We've introduced a new data structure, `OwnershipGraph`, which stores variables and their borrowed values in a `collections::BTreeMap` to maintain a consistent output order. This helps us to understand and verify the borrowing rules for each variable in the language.

 2. **Introduction of `build_ownership_graph` function**: This function takes a vector of `Statements` as an argument and generates an `OwnershipGraph`. This graph will be used to enforce borrowing rules and prevent multiple mutable references or simultaneous mutable and immutable references.

  3. **Writing Test Cases**: We have added comprehensive test cases for the `build_ownership_graph function`. These tests ensure that our implementation correctly handles variable declarations, borrowing, and the restrictions of Rust's ownership rules. Also, modefied other files tests too.
  
  ### TODO

 - [ ] should implement the borrow checker's functionality for nested scope.