### PR TITLE
Fix incorrect owner assignment

### DIFF
--- a/src/ownership.rs
+++ b/src/ownership.rs
@@ -86,9 +86,10 @@ fn build_ownership_graph(stmts: &[Statement]) -> Result<OwnershipGraph, OwnerGra
                         graph.add_borrower(&current_owner, name);
                         // current_owner = name.clone();
                     }
+                } else {
+                    current_owner = "".to_string();
                 }
                 graph.add_owner(&current_owner, name);
-                current_owner = name.clone();
             }
             Statement::Scope(scope) =>  {
                 let prev_owner = current_owner.clone();


### PR DESCRIPTION
The `build_ownership_graph` function where variables that are not borrowed were incorrectly assigned an owner. This problem was causing the generate ownership graph to incorrectly that some variables were being referenced by other variables when they were not.

The fix involves resetting the `current_owner` to an empty string whenever a variable that is not borrowed is encountered. This ensures that such variables are correctly recognized as independent owners in the ownership graph.